### PR TITLE
[#IOCOM-166] Fixed destroy handler with a NOOP

### DIFF
--- a/src/IncomingMessage.ts
+++ b/src/IncomingMessage.ts
@@ -74,7 +74,8 @@ export default class IncomingMessage extends Readable {
       connection: createConnectionObject(context),
       context: sanitizeContext(context), // Specific to Azure Function
       headers: req.headers || {}, // Should always have a headers object
-      socket: { destroy: NOOP },
+      socket: { destroy: NOOP }, // we should not destroy the socket
+      destroy: NOOP, // we are not interested in new destroy implementation
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       url: (req as any).originalUrl
     });

--- a/src/IncomingMessage.ts
+++ b/src/IncomingMessage.ts
@@ -73,9 +73,9 @@ export default class IncomingMessage extends Readable {
       ...req, // Inherit
       connection: createConnectionObject(context),
       context: sanitizeContext(context), // Specific to Azure Function
+      destroy: NOOP, // we are not interested in new destroy implementation
       headers: req.headers || {}, // Should always have a headers object
       socket: { destroy: NOOP }, // we should not destroy the socket
-      destroy: NOOP, // we are not interested in new destroy implementation
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       url: (req as any).originalUrl
     });


### PR DESCRIPTION
Node18 introduced a new destroy handler that seems to not be needed for our functions but was causing some functions to crash because of our custom IncomingMessage.

This fix binds a NOOP function to the destroy method of our IncomingMessage, as we did years ago with the socket.